### PR TITLE
update wrtc to fix ubuntu node-gyp build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "signalhub": "^1.1.0",
     "simple-peer": "^5.1.0",
     "through2": "^0.6.5",
-    "wrtc": "0.0.55"
+    "wrtc": "0.0.60"
   },
   "devDependencies": {
     "standard": "^3.6.1"


### PR DESCRIPTION
I updated wrtc ([issue](https://github.com/sinch/sinch-js-rtc/pull/6) to fix a build issue I was getting on ubuntu 16

`npm ERR! wrtc@0.0.55 install: `node-pre-gyp install --fallback-to-build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the wrtc@0.0.55 install script 'node-pre-gyp install --fallback-to-build'.
`